### PR TITLE
Add formula for CArL-Storm

### DIFF
--- a/Formula/carl-storm.rb
+++ b/Formula/carl-storm.rb
@@ -7,29 +7,25 @@ class CarlStorm < Formula
 
   head "https://github.com/moves-rwth/carl-storm.git", using: :git
 
-  option "with-thread-safe", "Build with thread-safe support"
-
   depends_on "boost"
   depends_on "cmake"
   depends_on "eigen"
   depends_on "gmp"
-  on_intel do
+ on_intel do
     depends_on "cln" => :optional
     depends_on "ginac" => :optional
   end
-  depends_on "moves-rwth/misc/cocoalib" => :optional
 
   def install
     args = %w[
       -DEXPORT_TO_CMAKE=OFF
       -DCMAKE_BUILD_TYPE=RELEASE
       -DEXCLUDE_TESTS_FROM_ALL=ON
+      -DTHREAD_SAFE=ON
     ]
-    args << "-DTHREAD_SAFE=ON" if build.with?("thread-safe")
     args << "-DUSE_CLN_NUMBERS=ON" if build.with?("cln") && Hardware::CPU.intel?
     args << "-DUSE_GINAC=ON" if build.with?("ginac") && Hardware::CPU.intel?
     args << "-DUSE_CLN_NUMBERS=OFF -DUSE_GINAC=OFF" if Hardware::CPU.arm?
-    args << "-DUSE_COCOA=ON" if build.with?("cocoalib")
 
     mktemp do
       system "cmake", buildpath, *(std_cmake_args + args)

--- a/Formula/carl-storm.rb
+++ b/Formula/carl-storm.rb
@@ -1,0 +1,39 @@
+class CarlStorm < Formula
+  desc "Computer ARithmetic and Logic library for the probabilistic model checker Storm"
+  homepage "https://ths-rwth.github.io/carl/"
+  url "https://github.com/moves-rwth/carl-storm/archive/refs/tags/14.25.tar.gz"
+  version "14.25"
+  sha256 "511740d53c2a6a41c3ccb3bd3b2d9ec89d0576f37b8804fc15fbe083e7a357da"
+
+  head "https://github.com/moves-rwth/carl-storm.git", using: :git
+
+  option "with-thread-safe", "Build with thread-safe support"
+
+  depends_on "boost"
+  depends_on "cmake"
+  depends_on "eigen"
+  depends_on "gmp"
+  on_intel do
+    depends_on "cln" => :optional
+    depends_on "ginac" => :optional
+  end
+  depends_on "moves-rwth/misc/cocoalib" => :optional
+
+  def install
+    args = %w[
+      -DEXPORT_TO_CMAKE=OFF
+      -DCMAKE_BUILD_TYPE=RELEASE
+      -DEXCLUDE_TESTS_FROM_ALL=ON
+    ]
+    args << "-DTHREAD_SAFE=ON" if build.with?("thread-safe")
+    args << "-DUSE_CLN_NUMBERS=ON" if build.with?("cln") && Hardware::CPU.intel?
+    args << "-DUSE_GINAC=ON" if build.with?("ginac") && Hardware::CPU.intel?
+    args << "-DUSE_CLN_NUMBERS=OFF -DUSE_GINAC=OFF" if Hardware::CPU.arm?
+    args << "-DUSE_COCOA=ON" if build.with?("cocoalib")
+
+    mktemp do
+      system "cmake", buildpath, *(std_cmake_args + args)
+      system "make", "install"
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a formula for the Storm verison of CArL in preparation of the release of Storm 1.8. The formula allows installation with optional dependencies CLN and GinaC on x86 architectures and disables the options (and corresponding support) on ARM/Apple Silicon.